### PR TITLE
Add service layer for DRE groups

### DIFF
--- a/app/domain/dre-groups/dre-groups.types.ts
+++ b/app/domain/dre-groups/dre-groups.types.ts
@@ -1,0 +1,29 @@
+export interface ServiceResult {
+  success: boolean;
+  data?: any;
+  error?: string;
+  message?: string;
+  fieldErrors?: Record<string, string>;
+}
+
+export interface ValidationResult {
+  success: boolean;
+  data?: any;
+  error?: string;
+  fieldErrors?: Record<string, string>;
+}
+
+export interface DreGroupFormData {
+  name: string;
+  order: number;
+  type: 'receita' | 'despesa' | 'resultado';
+}
+
+export interface CreateDreGroupData extends DreGroupFormData {}
+export interface UpdateDreGroupData extends DreGroupFormData {}
+
+export interface User {
+  id: string;
+  role: string;
+  accountingFirmId?: string;
+}

--- a/app/domain/dre-groups/services/dre-groups-crud.service.server.ts
+++ b/app/domain/dre-groups/services/dre-groups-crud.service.server.ts
@@ -1,0 +1,69 @@
+import prismaClient from '~/lib/prisma/client.server';
+import { ServiceResult, CreateDreGroupData, UpdateDreGroupData, User } from '../dre-groups.types';
+
+export class DreGroupsCRUDService {
+  constructor(private user: User) {}
+
+  async getAll(): Promise<ServiceResult> {
+    try {
+      const groups = await prismaClient.dREGroup.findMany({
+        orderBy: { order: 'asc' },
+      });
+      return { success: true, data: groups };
+    } catch (error: any) {
+      return { success: false, error: error.message || 'Erro ao listar grupos' };
+    }
+  }
+
+  async getById(groupId: string): Promise<ServiceResult> {
+    try {
+      const group = await prismaClient.dREGroup.findUnique({ where: { id: groupId } });
+      if (!group) return { success: false, error: 'Grupo não encontrado' };
+      return { success: true, data: group };
+    } catch (error: any) {
+      return { success: false, error: error.message || 'Erro ao buscar grupo' };
+    }
+  }
+
+  async create(data: CreateDreGroupData): Promise<ServiceResult> {
+    try {
+      this.checkAdmin();
+      const group = await prismaClient.dREGroup.create({ data });
+      return { success: true, data: group, message: 'Grupo criado com sucesso' };
+    } catch (error: any) {
+      return { success: false, error: error.message || 'Erro ao criar grupo' };
+    }
+  }
+
+  async update(groupId: string, data: UpdateDreGroupData): Promise<ServiceResult> {
+    try {
+      this.checkAdmin();
+      const existing = await prismaClient.dREGroup.findUnique({ where: { id: groupId } });
+      if (!existing) return { success: false, error: 'Grupo não encontrado' };
+      const group = await prismaClient.dREGroup.update({ where: { id: groupId }, data });
+      return { success: true, data: group, message: 'Grupo atualizado com sucesso' };
+    } catch (error: any) {
+      return { success: false, error: error.message || 'Erro ao atualizar grupo' };
+    }
+  }
+
+  async delete(groupId: string): Promise<ServiceResult> {
+    try {
+      this.checkAdmin();
+      const count = await prismaClient.account.count({ where: { dreGroupId: groupId } });
+      if (count > 0) {
+        return { success: false, error: 'Grupo possui contas vinculadas' };
+      }
+      await prismaClient.dREGroup.delete({ where: { id: groupId } });
+      return { success: true, message: 'Grupo excluído com sucesso' };
+    } catch (error: any) {
+      return { success: false, error: error.message || 'Erro ao excluir grupo' };
+    }
+  }
+
+  private checkAdmin() {
+    if (this.user.role !== 'admin') {
+      throw new Error('Acesso negado');
+    }
+  }
+}

--- a/app/domain/dre-groups/services/dre-groups-validation.service.server.ts
+++ b/app/domain/dre-groups/services/dre-groups-validation.service.server.ts
@@ -1,0 +1,70 @@
+import z from 'zod';
+import prismaClient from '~/lib/prisma/client.server';
+import { DreGroupFormData, ValidationResult } from '../dre-groups.types';
+
+export class DreGroupsValidationService {
+  async validateFormData(formData: DreGroupFormData): Promise<ValidationResult> {
+    const schema = z.object({
+      name: z
+        .string()
+        .min(3, 'Nome deve ter pelo menos 3 caracteres')
+        .max(100, 'Nome deve ter no máximo 100 caracteres')
+        .trim(),
+      order: z.number().int().nonnegative(),
+      type: z.enum(['receita', 'despesa', 'resultado']),
+    });
+
+    const result = schema.safeParse(formData);
+    if (!result.success) {
+      const fieldErrors = Object.fromEntries(
+        Object.entries(result.error.flatten().fieldErrors).map(([k, v]) => [
+          k,
+          v?.[0] ?? 'Erro de validação',
+        ])
+      );
+      return { success: false, fieldErrors };
+    }
+
+    return { success: true, data: result.data };
+  }
+
+  async validateBusinessRules(
+    data: DreGroupFormData,
+    groupId?: string
+  ): Promise<ValidationResult> {
+    try {
+      const [nameExists, orderExists] = await Promise.all([
+        prismaClient.dREGroup.findFirst({
+          where: {
+            name: { equals: data.name, mode: 'insensitive' },
+            ...(groupId && { id: { not: groupId } }),
+          },
+        }),
+        prismaClient.dREGroup.findFirst({
+          where: {
+            order: data.order,
+            ...(groupId && { id: { not: groupId } }),
+          },
+        }),
+      ]);
+
+      if (nameExists) {
+        return {
+          success: false,
+          fieldErrors: { name: 'Já existe um grupo com este nome' },
+        };
+      }
+
+      if (orderExists) {
+        return {
+          success: false,
+          fieldErrors: { order: 'Já existe um grupo com esta ordem' },
+        };
+      }
+
+      return { success: true };
+    } catch {
+      return { success: false, error: 'Erro na validação de regras de negócio' };
+    }
+  }
+}

--- a/app/domain/dre-groups/services/dre-groups.service.server.ts
+++ b/app/domain/dre-groups/services/dre-groups.service.server.ts
@@ -1,0 +1,54 @@
+import { CreateDreGroupData, UpdateDreGroupData, ServiceResult, User } from '../dre-groups.types';
+import { DreGroupsCRUDService } from './dre-groups-crud.service.server';
+import { DreGroupsValidationService } from './dre-groups-validation.service.server';
+
+export class DreGroupsService {
+  private crudService: DreGroupsCRUDService;
+  private validationService: DreGroupsValidationService;
+
+  constructor(user: User) {
+    this.crudService = new DreGroupsCRUDService(user);
+    this.validationService = new DreGroupsValidationService();
+  }
+
+  async create(data: CreateDreGroupData): Promise<ServiceResult> {
+    const validation = await this.validationService.validateFormData(data);
+    if (!validation.success) return validation;
+
+    const businessValidation = await this.validationService.validateBusinessRules(
+      validation.data!
+    );
+    if (!businessValidation.success) return businessValidation;
+
+    return this.crudService.create(validation.data!);
+  }
+
+  async update(groupId: string, data: UpdateDreGroupData): Promise<ServiceResult> {
+    const validation = await this.validationService.validateFormData(data);
+    if (!validation.success) return validation;
+
+    const businessValidation = await this.validationService.validateBusinessRules(
+      validation.data!,
+      groupId
+    );
+    if (!businessValidation.success) return businessValidation;
+
+    return this.crudService.update(groupId, validation.data!);
+  }
+
+  delete(groupId: string) {
+    return this.crudService.delete(groupId);
+  }
+
+  get getAll() {
+    return this.crudService.getAll.bind(this.crudService);
+  }
+
+  get getById() {
+    return this.crudService.getById.bind(this.crudService);
+  }
+}
+
+export function createDreGroupsService(user: User) {
+  return new DreGroupsService(user);
+}


### PR DESCRIPTION
## Summary
- create dre groups domain with types
- add validation service for groups
- add CRUD service for groups with admin check
- expose DreGroupsService factory

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68881ff328d4832a9391033ba068850a