### PR TITLE
Add DRE group service layer

### DIFF
--- a/app/domain/dre-groups/dre-groups.types.ts
+++ b/app/domain/dre-groups/dre-groups.types.ts
@@ -1,0 +1,30 @@
+export interface ServiceResult {
+  success: boolean;
+  data?: any;
+  error?: string;
+  message?: string;
+  fieldErrors?: Record<string, string>;
+}
+
+export interface ValidationResult {
+  success: boolean;
+  data?: any;
+  error?: string;
+  fieldErrors?: Record<string, string>;
+}
+
+export interface CreateDREGroupData {
+  name: string;
+  order: number;
+  type: 'receita' | 'despesa' | 'resultado';
+}
+
+export interface UpdateDREGroupData extends CreateDREGroupData {}
+
+export interface DREGroupFormData extends CreateDREGroupData {}
+
+export interface User {
+  id: string;
+  role: string;
+  accountingFirmId?: string;
+}

--- a/app/domain/dre-groups/services/dre-groups-audit.service.server.ts
+++ b/app/domain/dre-groups/services/dre-groups-audit.service.server.ts
@@ -1,0 +1,36 @@
+import { createAuditLog } from '~/domain/audit/audit.server';
+import { User } from '../dre-groups.types';
+
+export class DREGroupsAuditService {
+  constructor(private user: User) {}
+
+  async logCreate(groupId: string, data: any): Promise<void> {
+    await createAuditLog({
+      userId: this.user.id,
+      action: 'CREATE',
+      entity: 'DREGroup',
+      entityId: groupId,
+      details: data,
+    });
+  }
+
+  async logUpdate(groupId: string, data: any): Promise<void> {
+    await createAuditLog({
+      userId: this.user.id,
+      action: 'UPDATE',
+      entity: 'DREGroup',
+      entityId: groupId,
+      details: data,
+    });
+  }
+
+  async logDelete(groupId: string, data: any): Promise<void> {
+    await createAuditLog({
+      userId: this.user.id,
+      action: 'DELETE',
+      entity: 'DREGroup',
+      entityId: groupId,
+      details: data,
+    });
+  }
+}

--- a/app/domain/dre-groups/services/dre-groups-crud.service.server.ts
+++ b/app/domain/dre-groups/services/dre-groups-crud.service.server.ts
@@ -1,0 +1,92 @@
+import prismaClient from '~/lib/prisma/client.server';
+import {
+  ServiceResult,
+  CreateDREGroupData,
+  UpdateDREGroupData,
+  User,
+} from '../dre-groups.types';
+
+export class DREGroupsCRUDService {
+  constructor(private user: User) {}
+
+  async getAll(): Promise<ServiceResult> {
+    try {
+      const groups = await prismaClient.dREGroup.findMany({
+        orderBy: { order: 'asc' },
+      });
+      return { success: true, data: groups };
+    } catch (error: any) {
+      return { success: false, error: error.message || 'Erro ao buscar grupos' };
+    }
+  }
+
+  async getById(id: string): Promise<ServiceResult> {
+    try {
+      const group = await prismaClient.dREGroup.findUnique({ where: { id } });
+      if (!group) {
+        return { success: false, error: 'Grupo não encontrado' };
+      }
+      return { success: true, data: group };
+    } catch (error: any) {
+      return { success: false, error: error.message || 'Erro ao buscar grupo' };
+    }
+  }
+
+  async create(data: CreateDREGroupData): Promise<ServiceResult> {
+    try {
+      this.checkPermissions();
+      const newGroup = await prismaClient.dREGroup.create({ data });
+      return {
+        success: true,
+        data: newGroup,
+        message: 'Grupo criado com sucesso',
+      };
+    } catch (error: any) {
+      return { success: false, error: error.message || 'Erro ao criar grupo' };
+    }
+  }
+
+  async update(id: string, data: UpdateDREGroupData): Promise<ServiceResult> {
+    try {
+      this.checkPermissions();
+      const updatedGroup = await prismaClient.dREGroup.update({
+        where: { id },
+        data,
+      });
+      return {
+        success: true,
+        data: updatedGroup,
+        message: 'Grupo atualizado com sucesso',
+      };
+    } catch (error: any) {
+      return { success: false, error: error.message || 'Erro ao atualizar grupo' };
+    }
+  }
+
+  async delete(id: string): Promise<ServiceResult> {
+    try {
+      this.checkPermissions();
+      const accountsCount = await prismaClient.account.count({
+        where: { dreGroupId: id },
+      });
+
+      if (accountsCount > 0) {
+        return {
+          success: false,
+          error: 'Não é possível excluir grupo com contas vinculadas',
+        };
+      }
+
+      await prismaClient.dREGroup.delete({ where: { id } });
+      return { success: true, message: 'Grupo excluído com sucesso' };
+    } catch (error: any) {
+      return { success: false, error: error.message || 'Erro ao excluir grupo' };
+    }
+  }
+
+  private checkPermissions(): void {
+    if (this.user.role !== 'admin') {
+      throw new Error('Acesso negado');
+    }
+  }
+}

--- a/app/domain/dre-groups/services/dre-groups-validation.service.server.ts
+++ b/app/domain/dre-groups/services/dre-groups-validation.service.server.ts
@@ -1,0 +1,74 @@
+import z from 'zod';
+import prismaClient from '~/lib/prisma/client.server';
+import {
+  ValidationResult,
+  DREGroupFormData,
+  UpdateDREGroupData,
+} from '../dre-groups.types';
+
+export class DREGroupsValidationService {
+  async validateFormData(
+    formData: DREGroupFormData | UpdateDREGroupData
+  ): Promise<ValidationResult> {
+    const schema = z.object({
+      name: z
+        .string()
+        .min(3, 'Nome deve ter pelo menos 3 caracteres')
+        .max(100, 'Nome deve ter no máximo 100 caracteres')
+        .trim(),
+      order: z.number().int().positive('Ordem deve ser um número positivo'),
+      type: z.enum(['receita', 'despesa', 'resultado']),
+    });
+
+    const result = schema.safeParse(formData);
+
+    if (!result.success) {
+      const fieldErrors = Object.fromEntries(
+        Object.entries(result.error.flatten().fieldErrors).map(([key, val]) => [
+          key,
+          val?.[0] ?? 'Erro de validação',
+        ])
+      );
+
+      return { success: false, fieldErrors };
+    }
+
+    return { success: true, data: result.data };
+  }
+
+  async validateBusinessRules(
+    data: DREGroupFormData,
+    groupId?: string
+  ): Promise<ValidationResult> {
+    try {
+      const existingByName = await prismaClient.dREGroup.findFirst({
+        where: {
+          name: { equals: data.name, mode: 'insensitive' },
+          ...(groupId && { id: { not: groupId } }),
+        },
+      });
+
+      if (existingByName) {
+        return {
+          success: false,
+          fieldErrors: { name: 'Já existe um grupo com este nome' },
+        };
+      }
+
+      const existingByOrder = await prismaClient.dREGroup.findFirst({
+        where: { order: data.order, ...(groupId && { id: { not: groupId } }) },
+      });
+
+      if (existingByOrder) {
+        return {
+          success: false,
+          fieldErrors: { order: 'Já existe um grupo com esta ordem' },
+        };
+      }
+
+      return { success: true };
+    } catch {
+      return { success: false, error: 'Erro na validação de regras de negócio' };
+    }
+  }
+}

--- a/app/domain/dre-groups/services/dre-groups.service.server.ts
+++ b/app/domain/dre-groups/services/dre-groups.service.server.ts
@@ -1,0 +1,96 @@
+import { createAuditLog } from '~/domain/audit/audit.server';
+import {
+  CreateDREGroupData,
+  UpdateDREGroupData,
+  ServiceResult,
+  User,
+} from '../dre-groups.types';
+import { DREGroupsCRUDService } from './dre-groups-crud.service.server';
+import { DREGroupsValidationService } from './dre-groups-validation.service.server';
+
+export class DREGroupsService {
+  private crudService: DREGroupsCRUDService;
+  private validationService: DREGroupsValidationService;
+
+  constructor(user: User) {
+    this.crudService = new DREGroupsCRUDService(user);
+    this.validationService = new DREGroupsValidationService();
+  }
+
+  async create(data: CreateDREGroupData): Promise<ServiceResult> {
+    const validation = await this.validationService.validateFormData(data);
+    if (!validation.success) return validation;
+
+    const business = await this.validationService.validateBusinessRules(
+      validation.data!
+    );
+    if (!business.success) return business;
+
+    const result = await this.crudService.create(validation.data!);
+
+    if (result.success) {
+      await createAuditLog({
+        userId: this.crudService['user'].id,
+        action: 'CREATE',
+        entity: 'DREGroup',
+        entityId: result.data.id,
+        details: validation.data,
+      });
+    }
+
+    return result;
+  }
+
+  async update(id: string, data: UpdateDREGroupData): Promise<ServiceResult> {
+    const validation = await this.validationService.validateFormData(data);
+    if (!validation.success) return validation;
+
+    const business = await this.validationService.validateBusinessRules(
+      validation.data!,
+      id
+    );
+    if (!business.success) return business;
+
+    const result = await this.crudService.update(id, validation.data!);
+
+    if (result.success) {
+      await createAuditLog({
+        userId: this.crudService['user'].id,
+        action: 'UPDATE',
+        entity: 'DREGroup',
+        entityId: id,
+        details: validation.data,
+      });
+    }
+
+    return result;
+  }
+
+  async delete(id: string): Promise<ServiceResult> {
+    const result = await this.crudService.delete(id);
+
+    if (result.success) {
+      await createAuditLog({
+        userId: this.crudService['user'].id,
+        action: 'DELETE',
+        entity: 'DREGroup',
+        entityId: id,
+        details: {},
+      });
+    }
+
+    return result;
+  }
+
+  get getAll() {
+    return this.crudService.getAll.bind(this.crudService);
+  }
+
+  get getById() {
+    return this.crudService.getById.bind(this.crudService);
+  }
+}
+
+export function createDREGroupsService(user: User) {
+  return new DREGroupsService(user);
+}


### PR DESCRIPTION
## Summary
- implement service architecture for DRE groups
- add CRUD, validation and audit logging services
- expose a factory to create the DRE group service

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68881ff328d4832a9391033ba068850a